### PR TITLE
Change type of enum entry from uint8 to uint64 (for passing travis-ci tests)

### DIFF
--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -34,7 +34,7 @@ type Enum struct {
 }
 
 type EnumEntry struct {
-	Value       uint32            `xml:"value,attr"`
+	Value       uint64            `xml:"value,attr"`
 	Name        string            `xml:"name,attr"`
 	Description string            `xml:"description"`
 	Params      []*EnumEntryParam `xml:"param"`
@@ -371,7 +371,7 @@ const ({{range .Entries}}
 		e.Name = UpperCamelCase(e.Name)
 		for i, ee := range e.Entries {
 			if ee.Value == 0 {
-				ee.Value = uint32(i)
+				ee.Value = uint64(i)
 			}
 			ee.Description = strings.Replace(ee.Description, "\n", " ", -1)
 		}

--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -34,7 +34,7 @@ type Enum struct {
 }
 
 type EnumEntry struct {
-	Value       uint64            `xml:"value,attr"`
+	Value       uint32            `xml:"value,attr"`
 	Name        string            `xml:"name,attr"`
 	Description string            `xml:"description"`
 	Params      []*EnumEntryParam `xml:"param"`
@@ -371,7 +371,7 @@ const ({{range .Entries}}
 		e.Name = UpperCamelCase(e.Name)
 		for i, ee := range e.Entries {
 			if ee.Value == 0 {
-				ee.Value = uint64(i)
+				ee.Value = uint32(i)
 			}
 			ee.Description = strings.Replace(ee.Description, "\n", " ", -1)
 		}

--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -34,7 +34,7 @@ type Enum struct {
 }
 
 type EnumEntry struct {
-	Value       uint16            `xml:"value,attr"`
+	Value       uint64            `xml:"value,attr"`
 	Name        string            `xml:"name,attr"`
 	Description string            `xml:"description"`
 	Params      []*EnumEntryParam `xml:"param"`
@@ -371,7 +371,7 @@ const ({{range .Entries}}
 		e.Name = UpperCamelCase(e.Name)
 		for i, ee := range e.Entries {
 			if ee.Value == 0 {
-				ee.Value = uint16(i)
+				ee.Value = uint64(i)
 			}
 			ee.Description = strings.Replace(ee.Description, "\n", " ", -1)
 		}

--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -34,7 +34,7 @@ type Enum struct {
 }
 
 type EnumEntry struct {
-	Value       uint8             `xml:"value,attr"`
+	Value       uint16            `xml:"value,attr"`
 	Name        string            `xml:"name,attr"`
 	Description string            `xml:"description"`
 	Params      []*EnumEntryParam `xml:"param"`
@@ -371,7 +371,7 @@ const ({{range .Entries}}
 		e.Name = UpperCamelCase(e.Name)
 		for i, ee := range e.Entries {
 			if ee.Value == 0 {
-				ee.Value = uint8(i)
+				ee.Value = uint16(i)
 			}
 			ee.Description = strings.Replace(ee.Description, "\n", " ", -1)
 		}


### PR DESCRIPTION
Hi!
I was change type of enum entry from uint8 to uint16. This need for my private dialect. For example I have entry like this
```
    <enum name="MY_DIALECT_PARAM">
      <entry value="2048" name="MY_DIALECT_PARAM_END">
        <description></description>
      </entry>
    </enum>
```
And for value="2048" go-mavlink not generate go-sources